### PR TITLE
attribution_position_based fix

### DIFF
--- a/marketing_attribution_models/MAM.py
+++ b/marketing_attribution_models/MAM.py
@@ -1081,7 +1081,7 @@ class MAM:
                 [list_positions_first_middle_last[0]]
                 + [list_positions_first_middle_last[1] / (len(canais) - 2)]
                 * (len(canais) - 2)
-                + [list_positions_first_middle_last[0]]
+                + [list_positions_first_middle_last[2]]
             )
         )
         # multiplying the results with the conversion value


### PR DESCRIPTION
**What issue does this pull request resolve?**
A função de atribuição position based estava ignorando o terceiro argumento (peso do last_click) para jornadas maiores de dois touchpoints, e usando o valor do first-click duas vezes. Esse pull faz a função utilizar o valor correto.

**What changes did you make?**
Modifiquei a parte de distribuição de valores para jornadas com mais de 2 touchpoints no modelo attribution_position_based 

**Is there anything that requires more attention while reviewing?**