### PR TITLE
fix: corrige tipo do build_command no pyproject.toml para string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ version_variable = [
   'setup.py:__version__'
 ]
 version_source = 'tag'
-build_command = false
+build_command = ""


### PR DESCRIPTION
**What issue does this pull request resolve?**
Resolve o problema de release do pacote relacionado ao tipo de dado do campo build_command do arquivo pyproject.toml

**What changes did you make?**
o valor do campo foi trocade um booleano false para uma string vazia

**Is there anything that requires more attention while reviewing?**